### PR TITLE
adding ‘Isolation view’

### DIFF
--- a/app/controllers/library_controller.rb
+++ b/app/controllers/library_controller.rb
@@ -3,12 +3,14 @@ class LibraryController < ApplicationController
 
   def index
     dir = Dir.glob("#{Rails.root}/app/views/#{ComponentLibrary.root_directory}/**/*.erb").sort
+    @component_template = 'componentpattern'
     @library = Library::Librarian.new(dir, ComponentLibrary.root_directory)
   end
 
   def show
     suffix = params[:format] == 'erb' ? ".erb" : "/**/*.erb"
     dir = Dir.glob("#{Rails.root}/app/views/#{ComponentLibrary.root_directory}/#{params[:path]}#{suffix}").sort
+    @component_template = params[:view] == 'isolation' ? 'isolationpattern' : 'componentpattern'
     @library = Library::Librarian.new(dir, ComponentLibrary.root_directory, params[:path])
     raise ActionController::RoutingError.new('Not Found') if @library.components.empty?
   end

--- a/app/views/library/_componentpattern.html.erb
+++ b/app/views/library/_componentpattern.html.erb
@@ -1,4 +1,5 @@
-<% components.each do |component| %>
+<h1><%= library.title.capitalize %></h1>
+<% library.components.each do |component| %>
 <p class="pattern--title">
   <% component.paths.each do |path| %>
     /<%= link_to path[:name], component_path(path[:path]) %>

--- a/app/views/library/_isolationpattern.html.erb
+++ b/app/views/library/_isolationpattern.html.erb
@@ -1,0 +1,3 @@
+<% library.components.each do |component| %>
+  <%= render component.render %>
+<% end %>

--- a/app/views/library/index.html.erb
+++ b/app/views/library/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Component Library</h1>
 <% if @library.components.any? %>
-<%= render partial: "componentpattern", locals: { components: @library.components }  %>
+<%= render partial: @component_template, locals: { library: @library }  %>
 <% else %>
 <p>No html components found at <code>/app/view/<%= ComponentLibrary.root_directory %></code></p>
 <% end %>

--- a/app/views/library/show.html.erb
+++ b/app/views/library/show.html.erb
@@ -1,2 +1,1 @@
-<h1><%= @library.title.capitalize %></h1>
-<%= render partial: "componentpattern", locals: { components: @library.components }  %>
+<%= render partial: @component_template, locals: { library: @library }  %>

--- a/spec/controllers/library_controller_spec.rb
+++ b/spec/controllers/library_controller_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe ComponentLibrary::LibraryController, :type => :controller do
       expect(assigns(:library)).to_not be_nil
     end
 
+    it "assigns @component_template" do
+      expect(assigns(:component_template)).to eq 'componentpattern'
+    end
+
     it "assigns all component files to @library.components" do
       expect(assigns(:library).components.length).to eq 3
     end
@@ -28,9 +32,9 @@ RSpec.describe ComponentLibrary::LibraryController, :type => :controller do
   end
 
   describe "GET #show" do
-    def get_show(url, format=nil)
+    def get_show(url, format=nil, view=nil)
       @url = url
-      get :show, path: url, format: format
+      get :show, path: url, format: format, view: view
     end
 
     it "responds successfully with an HTTP 200 status code" do
@@ -54,11 +58,22 @@ RSpec.describe ComponentLibrary::LibraryController, :type => :controller do
       expect(assigns(:library).components.length).to eq 1
     end
 
+    it "assigns @component_template" do
+      get_show('_buttons.html', 'erb')
+      expect(assigns(:component_template)).to eq 'componentpattern'
+    end
+
+    it "assigns @component_template with isolation pattern if paramter is provided" do
+      get_show('_buttons.html', 'erb', 'isolation')
+      expect(assigns(:component_template)).to eq 'isolationpattern'
+    end
+
     it "returns a 404 if no components are found" do
       expect {
         get_show('headings/_foo.html', 'erb')
       }.to raise_error(ActionController::RoutingError)
     end
+
 
   end
 end


### PR DESCRIPTION
optionally rendering components without any CompLib chrome by adding `?view=isolation`

Have only made the option available for individual and sub-grouped components, not the entire view, but there is no reason why not, I suppose
